### PR TITLE
Added the ability to retrieve shortversion (version)

### DIFF
--- a/lib/fastlane/plugin/latest_hockeyapp_version_number/actions/latest_hockeyapp_version_number_action.rb
+++ b/lib/fastlane/plugin/latest_hockeyapp_version_number/actions/latest_hockeyapp_version_number_action.rb
@@ -13,9 +13,11 @@ module Fastlane
         apps = client.get_apps
         app = apps.find { |a| a.title == params[:app_name] && a.platform == params[:platform] && a.release_type == params[:release_type].to_i }
         version = app.versions.first.version.to_i
+        shortversion = app.versions.first.shortversion
         UI.message "Found version #{version}"
+        UI.message "Found shortversion #{shortversion}"
 
-        version
+        version, shortversion
       end
 
       def self.description


### PR DESCRIPTION
This is the pull request for fix the issue #1 .
Now the plugin returns the shortversion in addition to version from HockeyApp.
As you can see in the HockeyApp's dashboard,  _shortversion_ and _version_ are called respectively _version_ and _build_.

<img width="369" alt="screen shot 2016-10-23 at 13 49 12" src="https://cloud.githubusercontent.com/assets/4321291/19626044/79e3dcda-9928-11e6-9c99-08a8b4d136f7.png">
